### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/claude-pr-metadata-update.yml
+++ b/.github/workflows/claude-pr-metadata-update.yml
@@ -17,6 +17,9 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
 
+permissions:
+  contents: read
+
 # Concurrency: Cancel in-flight runs for the same PR
 concurrency:
   group: pr-metadata-${{ github.event.pull_request.number }}


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/sdks/security/code-scanning/14](https://github.com/Dargon789/sdks/security/code-scanning/14)

In general, the fix is to explicitly declare the GITHUB_TOKEN permissions for this workflow, reducing them to the minimal scopes required. Since this workflow only triggers on `pull_request` events and delegates work to a reusable workflow, a safe baseline is to set read-only access to repository contents. If the reusable workflow needs to write to the PR (e.g., updating title/description or comments), the reusable workflow itself should declare those write permissions. At the caller level here, a conservative and correct fix that does not break existing behavior is to add a root-level `permissions:` block granting only `contents: read`, which is equivalent to the standard read-only default.

Concretely, edit `.github/workflows/claude-pr-metadata-update.yml` and insert a `permissions:` section near the top, after the `on:` block (or before `jobs:`). This block will apply to all jobs in the workflow that do not override permissions. No additional imports or external libraries are needed, as this is purely a GitHub Actions YAML configuration change. The rest of the workflow remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Build:
- Add a root-level permissions block granting read-only access to repository contents in the claude-pr-metadata-update GitHub Actions workflow.