### PR TITLE
Uniswap sdk (#66)

### DIFF
--- a/sdks/smart-wallet-sdk/src/smartWallet.test.ts
+++ b/sdks/smart-wallet-sdk/src/smartWallet.test.ts
@@ -1,15 +1,153 @@
 import { ChainId } from '@uniswap/sdk-core'
-import { decodeFunctionData } from 'viem'
+import { decodeAbiParameters, decodeFunctionData } from 'viem'
 
 import abi from '../abis/MinimalDelegationEntry.json'
 
 import { ModeType, SMART_WALLET_ADDRESSES } from './constants'
 import { SmartWallet } from './smartWallet'
 import { BatchedCall, Call } from './types'
+import { BATCHED_CALL_ABI_PARAMS } from './utils/batchedCallPlanner'
 
 const EXECUTE_SELECTOR = '0xe9ae5c53' as `0x${string}`
+const EXECUTE_USER_OP_SELECTOR = '0x8dd7712f' as `0x${string}`
 
 describe('SmartWallet', () => {
+  describe('encodeUserOp', () => {
+    it('encodes a single call correctly', () => {
+      const calls: Call[] = [
+        {
+          to: '0x1111111111111111111111111111111111111111',
+          data: '0x1234',
+          value: 0n,
+        },
+      ]
+
+      const result = SmartWallet.encodeUserOp(calls)
+
+      expect(result).toBeDefined()
+      expect(result.calldata).toBeDefined()
+      expect(result.calldata.startsWith(EXECUTE_USER_OP_SELECTOR)).toBe(true)
+      expect(result.value).toBe(0n)
+    })
+
+    it('encodes multiple calls correctly', () => {
+      const calls: Call[] = [
+        {
+          to: '0x1111111111111111111111111111111111111111',
+          data: '0x1234',
+          value: 0n,
+        },
+        {
+          to: '0x2222222222222222222222222222222222222222',
+          data: '0x5678',
+          value: 0n,
+        },
+      ]
+
+      const result = SmartWallet.encodeUserOp(calls)
+
+      expect(result).toBeDefined()
+      expect(result.calldata).toBeDefined()
+      expect(result.calldata.startsWith(EXECUTE_USER_OP_SELECTOR)).toBe(true)
+      expect(result.value).toBe(0n)
+    })
+
+    it('sums the value of all calls', () => {
+      const calls: Call[] = [
+        {
+          to: '0x1111111111111111111111111111111111111111',
+          data: '0x1234',
+          value: 100n,
+        },
+        {
+          to: '0x2222222222222222222222222222222222222222',
+          data: '0x5678',
+          value: 200n,
+        },
+      ]
+
+      const result = SmartWallet.encodeUserOp(calls)
+
+      expect(result.value).toBe(300n)
+    })
+
+    it('encodes with revertOnFailure: true', () => {
+      const calls: Call[] = [
+        {
+          to: '0x1111111111111111111111111111111111111111',
+          data: '0x1234',
+          value: 0n,
+        },
+      ]
+
+      const result = SmartWallet.encodeUserOp(calls, { revertOnFailure: true })
+
+      expect(result).toBeDefined()
+      expect(result.calldata).toBeDefined()
+      expect(result.calldata.startsWith(EXECUTE_USER_OP_SELECTOR)).toBe(true)
+      
+      // Decode using BATCHED_CALL_ABI_PARAMS which matches the encoding format
+      const argsData = `0x${result.calldata.slice(10)}` as `0x${string}`
+      const decoded = decodeAbiParameters(BATCHED_CALL_ABI_PARAMS, argsData)
+      expect((decoded[0] as BatchedCall).revertOnFailure).toBe(true)
+    })
+
+    it('encodes with revertOnFailure: false', () => {
+      const calls: Call[] = [
+        {
+          to: '0x1111111111111111111111111111111111111111',
+          data: '0x1234',
+          value: 0n,
+        },
+      ]
+
+      const result = SmartWallet.encodeUserOp(calls, { revertOnFailure: false })
+
+      expect(result).toBeDefined()
+      expect(result.calldata).toBeDefined()
+
+      // Decode using BATCHED_CALL_ABI_PARAMS which matches the encoding format
+      const argsData = `0x${result.calldata.slice(10)}` as `0x${string}`
+      const decoded = decodeAbiParameters(BATCHED_CALL_ABI_PARAMS, argsData)
+      expect((decoded[0] as BatchedCall).revertOnFailure).toBe(false)
+    })
+
+    it('defaults revertOnFailure to true when no options provided', () => {
+      const calls: Call[] = [
+        {
+          to: '0x1111111111111111111111111111111111111111',
+          data: '0x1234',
+          value: 0n,
+        },
+      ]
+
+      const result = SmartWallet.encodeUserOp(calls)
+
+      // Decode using BATCHED_CALL_ABI_PARAMS which matches the encoding format
+      const argsData = `0x${result.calldata.slice(10)}` as `0x${string}`
+      const decoded = decodeAbiParameters(BATCHED_CALL_ABI_PARAMS, argsData)
+      // When no option is provided, BatchedCallPlanner defaults revertOnFailure to true
+      expect((decoded[0] as BatchedCall).revertOnFailure).toBe(true)
+    })
+
+    it('handles calls with chainId property', () => {
+      const calls: Call[] = [
+        {
+          to: '0x1111111111111111111111111111111111111111',
+          data: '0x1234',
+          value: 50n,
+          chainId: ChainId.SEPOLIA,
+        },
+      ]
+
+      const result = SmartWallet.encodeUserOp(calls)
+
+      expect(result).toBeDefined()
+      expect(result.calldata.startsWith(EXECUTE_USER_OP_SELECTOR)).toBe(true)
+      expect(result.value).toBe(50n)
+    })
+  })
+
   describe('encodeBatchedCall', () => {
     it('encodes batched call correctly', () => {
       const calls: Call[] = [

--- a/sdks/smart-wallet-sdk/src/smartWallet.ts
+++ b/sdks/smart-wallet-sdk/src/smartWallet.ts
@@ -1,5 +1,5 @@
 import { ChainId } from '@uniswap/sdk-core'
-import { encodeFunctionData } from 'viem'
+import { concatHex, encodeFunctionData } from 'viem'
 
 import abi from '../abis/MinimalDelegationEntry.json'
 
@@ -12,6 +12,34 @@ import { BatchedCallPlanner } from './utils/batchedCallPlanner'
  * Main SDK class for interacting with Uniswap smart wallet contracts
  */
 export class SmartWallet {
+  /**
+   * Creates method parameters for a UserOperation to be executed through a smart wallet
+   * @dev Compatible with EntryPoint versions v0.7.0 and v0.8.0 (not v0.6.0)
+   * 
+   * @param calls Array of calls to encode
+   * @param options Basic options for the execution
+   * @returns Method parameters with userOp calldata and value
+   */
+  public static encodeUserOp(calls: Call[], options: ExecuteOptions = {}): MethodParameters {
+    const planner = new CallPlanner(calls)
+    const batchedCallPlanner = new BatchedCallPlanner(planner, options.revertOnFailure)
+
+    // UserOp callData format: executeUserOp selector (0x8dd7712f) + abi.encode(abi.encode(Call[]), revertOnFailure)
+
+    // The EntryPoint recognizes this selector and calls executeUserOp(userOp, userOpHash) on the account.
+    // The account then extracts the execution data from userOp.callData (slicing off the selector).
+    
+    // We manually concat the selector + encoded data rather than using encodeFunctionData because
+    // the callData is not a standard ABI-encoded function call to executeUserOp.
+    const EXECUTE_USER_OP_SELECTOR = '0x8dd7712f' as const
+    const calldata = concatHex([EXECUTE_USER_OP_SELECTOR, batchedCallPlanner.encode()])
+
+    return {
+      calldata,
+      value: planner.value,
+    }
+  }
+
   /**
    * Creates method parameters for executing a simple batch of calls through a smart wallet
    * @param calls Array of calls to encode

--- a/sdks/uniswapx-sdk/integration/package.json
+++ b/sdks/uniswapx-sdk/integration/package.json
@@ -16,7 +16,7 @@
   },
   "author": "Uniswap",
   "devDependencies": {
-    "@nomicfoundation/hardhat-chai-matchers": "1.0.6",
+    "@nomicfoundation/hardhat-chai-matchers": "2.0.1",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.10",
     "@nomiclabs/hardhat-ethers": "^2.2.3",
     "@types/chai": "^4.3.3",


### PR DESCRIPTION
* chore(v3-sdk): annotate FACTORY_ADDRESS as deprecated

* chore(v3-sdk): annotate FACTORY_ADDRESS as deprecated

* remove .idea artifact

* Create SECURITY.md



* chore(deps): bump @openzeppelin/contracts (#1)

Bumps the npm_and_yarn group with 1 update in the / directory: [@openzeppelin/contracts](https://github.com/OpenZeppelin/openzeppelin-contracts).


Updates `@openzeppelin/contracts` from 4.7.0 to 4.9.6
- [Release notes](https://github.com/OpenZeppelin/openzeppelin-contracts/releases)
- [Changelog](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CHANGELOG.md)
- [Commits](https://github.com/OpenZeppelin/openzeppelin-contracts/compare/v4.7.0...v4.9.6)

---
updated-dependencies:
- dependency-name: "@openzeppelin/contracts" dependency-type: direct:production dependency-group: npm_and_yarn ...




* chore(deps): bump the npm_and_yarn group across 1 directory with 5 updates (#2)

Bumps the npm_and_yarn group with 5 updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| [@openzeppelin/contracts](https://github.com/OpenZeppelin/openzeppelin-contracts) | `4.9.6` | `5.0.2` | | [follow-redirects](https://github.com/follow-redirects/follow-redirects) | `1.15.3` | `1.15.9` | | [secp256k1](https://github.com/cryptocoinjs/secp256k1-node) | `4.0.3` | `4.0.4` | | [tar](https://github.com/isaacs/node-tar) | `6.2.0` | `6.2.1` | | [undici](https://github.com/nodejs/undici) | `5.28.2` | `5.28.4` |



Updates `@openzeppelin/contracts` from 4.9.6 to 5.0.2
- [Release notes](https://github.com/OpenZeppelin/openzeppelin-contracts/releases)
- [Changelog](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CHANGELOG.md)
- [Commits](https://github.com/OpenZeppelin/openzeppelin-contracts/compare/v4.9.6...v5.0.2)

Updates `follow-redirects` from 1.15.3 to 1.15.9
- [Release notes](https://github.com/follow-redirects/follow-redirects/releases)
- [Commits](https://github.com/follow-redirects/follow-redirects/compare/v1.15.3...v1.15.9)

Updates `secp256k1` from 4.0.3 to 4.0.4
- [Release notes](https://github.com/cryptocoinjs/secp256k1-node/releases)
- [Commits](https://github.com/cryptocoinjs/secp256k1-node/compare/v4.0.3...v4.0.4)

Updates `tar` from 6.2.0 to 6.2.1
- [Release notes](https://github.com/isaacs/node-tar/releases)
- [Changelog](https://github.com/isaacs/node-tar/blob/main/CHANGELOG.md)
- [Commits](https://github.com/isaacs/node-tar/compare/v6.2.0...v6.2.1)

Updates `undici` from 5.28.2 to 5.28.4
- [Release notes](https://github.com/nodejs/undici/releases)
- [Commits](https://github.com/nodejs/undici/compare/v5.28.2...v5.28.4)

---
updated-dependencies:
- dependency-name: "@openzeppelin/contracts" dependency-type: direct:production dependency-group: npm_and_yarn
- dependency-name: follow-redirects dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: secp256k1 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: tar dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: undici dependency-type: indirect dependency-group: npm_and_yarn ...




* chore(deps): bump @openzeppelin/contracts (#3)

Bumps the npm_and_yarn group with 1 update in the / directory: [@openzeppelin/contracts](https://github.com/OpenZeppelin/openzeppelin-contracts).


Updates `@openzeppelin/contracts` from 5.0.2 to 5.1.0
- [Release notes](https://github.com/OpenZeppelin/openzeppelin-contracts/releases)
- [Changelog](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CHANGELOG.md)
- [Commits](https://github.com/OpenZeppelin/openzeppelin-contracts/compare/v5.0.2...v5.1.0)

---
updated-dependencies:
- dependency-name: "@openzeppelin/contracts" dependency-type: direct:production dependency-group: npm_and_yarn ...




* Update issue templates

* Create jekyll-gh-pages.yml



* Create google.yml



* fix: sdks/v3-sdk/package.json to reduce vulnerabilities (#6)

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-ELLIPTIC-8720086
- https://snyk.io/vuln/SNYK-JS-ELLIPTIC-7577916
- https://snyk.io/vuln/SNYK-JS-ELLIPTIC-7577917
- https://snyk.io/vuln/SNYK-JS-ELLIPTIC-7577918
- https://snyk.io/vuln/SNYK-JS-ELLIPTIC-8172694



* fix: sdks/uniswapx-sdk/package.json to reduce vulnerabilities (#7)

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-WS-7266574



* fix: sdks/uniswapx-sdk/integration/package.json to reduce vulnerabilities (#5)

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-ELLIPTIC-8720086
- https://snyk.io/vuln/SNYK-JS-ELLIPTIC-8187303
- https://snyk.io/vuln/SNYK-JS-ELLIPTIC-7577916
- https://snyk.io/vuln/SNYK-JS-ELLIPTIC-7577917
- https://snyk.io/vuln/SNYK-JS-ELLIPTIC-7577918



* Add .circleci/config.yml (#9)

* fix: sdks/v2-sdk/package.json to reduce vulnerabilities (#12)

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-BRACES-6838727
- https://snyk.io/vuln/SNYK-JS-CROSSSPAWN-8303230
- https://snyk.io/vuln/SNYK-JS-WS-7266574
- https://snyk.io/vuln/SNYK-JS-MICROMATCH-6838728
- https://snyk.io/vuln/SNYK-JS-TOUGHCOOKIE-5672873
- https://snyk.io/vuln/SNYK-JS-UNSETVALUE-2400660
- https://snyk.io/vuln/SNYK-JS-REQUEST-3361831



* fix: sdks/permit2-sdk/package.json to reduce vulnerabilities (#13)

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-BRACES-6838727
- https://snyk.io/vuln/SNYK-JS-CROSSSPAWN-8303230
- https://snyk.io/vuln/SNYK-JS-MICROMATCH-6838728
- https://snyk.io/vuln/SNYK-JS-REQUEST-3361831
- https://snyk.io/vuln/SNYK-JS-TOUGHCOOKIE-5672873
- https://snyk.io/vuln/SNYK-JS-UNSETVALUE-2400660
- https://snyk.io/vuln/SNYK-JS-WS-7266574



* fix: sdks/universal-router-sdk/package.json to reduce vulnerabilities (#16)

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-PBKDF2-10495496
- https://snyk.io/vuln/SNYK-JS-PBKDF2-10495498



* feat(the-compact-sdk): add complex nested mandate type support

Fix witness typestring generation to omit final closing parenthesis per The Compact spec, and add comprehensive tests validating complex nested mandate structures like those used in Tribunal.

Changes:
- Fix buildWitnessTypestring to remove final closing paren
- Add 8 new tests for complex nested mandate types
- Test simple nested structures
- Test arrays in nested structures
- Test alphabetical sorting of multiple nested types
- Test Tribunal-like deeply nested structures with recursive refs
- Test full Tribunal-style mandate with 5 nested types
- Test bytes vs bytes32 in nested structures

Added comprehensive tests to validate SDK mandate encoding against Tribunal's reference implementation:

- Nested custom types (Mandate_*)
- Arrays of nested types (Mandate_Fill[])
- Recursive type references (Mandate_Compact contains Mandate)
- Complex multi-level nesting (up to 5 nested types)
- Mandate typehash matches Tribunal's MANDATE_TYPEHASH constant
- Mandate_Fill typehash matches MANDATE_FILL_TYPEHASH
- Mandate_FillComponent typehash matches MANDATE_FILL_COMPONENT_TYPEHASH
- Mandate_Lock typehash matches MANDATE_LOCK_TYPEHASH
- All typehashes computed from typestrings match Tribunal contract constants
- Full Tribunal mandate encoding test case from TribunalBasicTest.sol
- Validates encoding structure (address + fillsHash = 64 bytes)
- Verifies hash computation is deterministic

These tests ensure the SDK's EIP-712 encoding is compatible with Tribunal's on-chain mandate derivation functions (deriveMandateHash, deriveFillHash).

* chore: add coverage config, more tests and TSDoc

1) Add collectCoverageFrom and coverage reporting configuration to enable test coverage measurement. Includes text, text-summary, and HTML reporters.

2) Add complete parameter and return type documentation to all functions:

Price Curve Library:
- Document all parameters with types and descriptions
- Add return type documentation with value ranges
- Clarify scaling factor semantics (1e18 = neutral)
- Document error conditions and edge cases

Tribunal Builders:
- Full @param documentation for all builder methods
- Document chaining behavior with @returns
- Add class-level documentation with usage examples
- Document build() method preconditions

Convenience Functions:
- Complete parameter documentation for createSameChainFill()
- Full parameter docs for createCrossChainFill()
- Clarify cross-chain callback semantics

3) Add many new test cases for claim and batch claim functionality

* feat(client): complete ArbiterClient with multichain support and TSDoc

* test(client): add comprehensive unit tests

* chore(test, doc): update to jest 29.x, add comprehensive TSDoc to builders

Add extensive class-level and method documentation to all builder classes in compact.ts and claim.ts, improving API discoverability and usage examples.

* docs: create comprehensive README with detailed SDK usage guide

Replace basic README with comprehensive documentation covering all aspects of the SDK usage, from installation to advanced patterns.

* feat(e2e): add comprehensive end-to-end integration test suite

Add functional e2e tests using Supersim for testing against forked chains

* test(e2e): add comprehensive batch compact test with multiple reset periods

Add E2E test demonstrating batch compacts covering multiple resource locks with different reset periods, processed in a single batch claim transaction.

* feat(builders): add fromCompact() method to batch claim builders

Add a simpler `fromCompact()` method to BaseBatchClaimBuilder that pre-fills sponsor, nonce, expires, and signature from a BatchCompact struct without requiring ids/amounts upfront. This provides a cleaner API for building batch claims:

Before:
  ClaimBuilder.batch(domain)
    .sponsor(compact.sponsor)
    .nonce(compact.nonce)
    .expires(compact.expires)
    .addClaim()...

After:
  ClaimBuilder.batch(domain)
    .fromCompact({ compact, signature })
    .addClaim()...

The method is inherited by BatchClaimBuilder, BatchMultichainClaimBuilder, and ExogenousBatchMultichainClaimBuilder, providing consistent API across all batch claim builder types.

* chore(docs): update E2E_TESTING.md

* Update README.md

* Update README.md

* chore(eslint): resolve eslint warnings

* chore(monorepo): update yarn.lock

* chore(eslint): resolve remaining code style warnings

* chore(monorepo): modify deps to more closely match monorepo

* chore(ci): resolve monorepo dep mismatch

* feat(price-curves): add various price curve calculators and utilities

Add calculators for various auction types including dutch and reverse dutch, stepped schedules and multi-phase auctions, as well as utils for conversion, evaluation and validation of curve configurations.

- Dutch auction curves (exact-in mode, decreasing prices)
- Reverse Dutch auction curves (exact-out mode, increasing prices)
- Stepped price calculators with configurable intervals
- Multi-phase auction builder supporting N phases
- Percentage conversion utilities
- Price evaluation and validation helpers
- Curve composition tools (concatenate, plateau, flat price)

* feat(mandate): add official TribunalMandate type and update README

Add the official Tribunal allocator mandate type definition to the SDK and update README documentation with accurate usage examples.

1. **New TribunalMandate export** in src/builders/mandate.ts:
   - Complete type definition matching official Tribunal allocator structure
   - Includes all nested types: Fill, FillComponent, Lock, BatchCompact, RecipientCallback
   - Supports dynamic pricing via priceCurve arrays (compatible with price curve calculators)

2. **README improvements**:
   - Show integration with price curve calculators (createDutchAuction)
   - Demonstrate actual Tribunal mandate structure with all required fields
   - Document dynamic pricing, cross-chain fills, fill validation, callbacks

* feat: add CLAUDE.md documentation

* docs(readme): demonstrate TribunalBuilder fluent API

Update README to showcase the TribunalBuilder's fluent interface for composing Tribunal mandates, rather than passing inline configuration objects.

Example pattern:
```typescript
const mandate = TribunalBuilder.mandate()
  .adjuster(adjuster)
  .fill(f => f.chainId(1n).tribunal(addr).component(c => ...))
  .build()

const compact = await client.sponsor.compact()
  // ...
  .witness(TribunalMandate, mandate)
  .build()
```

* fix: package.json to reduce vulnerabilities (#17)

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-JSYAML-13961110



* fix: sdks/universal-router-sdk/package.json to reduce vulnerabilities (#15)

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-BRACEEXPANSION-9789073



* chore(deps): bump the npm_and_yarn group across 1 directory with 2 updates

Bumps the npm_and_yarn group with 2 updates in the / directory: [@openzeppelin/contracts](https://github.com/OpenZeppelin/openzeppelin-contracts) and [undici](https://github.com/nodejs/undici).


Updates `@openzeppelin/contracts` from 5.1.0 to 5.2.0
- [Release notes](https://github.com/OpenZeppelin/openzeppelin-contracts/releases)
- [Changelog](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CHANGELOG.md)
- [Commits](https://github.com/OpenZeppelin/openzeppelin-contracts/compare/v5.1.0...v5.2.0)

Updates `undici` from 5.28.4 to 5.28.5
- [Release notes](https://github.com/nodejs/undici/releases)
- [Commits](https://github.com/nodejs/undici/compare/v5.28.4...v5.28.5)

---
updated-dependencies:
- dependency-name: "@openzeppelin/contracts" dependency-type: direct:production dependency-group: npm_and_yarn
- dependency-name: undici dependency-type: indirect dependency-group: npm_and_yarn ...



* fix: sdks/universal-router-sdk/package.json to reduce vulnerabilities

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-OPENZEPPELINCONTRACTS-10773735

* Update monorepo-integrity.yml



* chore(deps): bump the npm_and_yarn group across 2 directories with 9 updates

Bumps the npm_and_yarn group with 9 updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| [@openzeppelin/contracts](https://github.com/OpenZeppelin/openzeppelin-contracts) | `5.2.0` | `5.4.0` | | [@babel/helpers](https://github.com/babel/babel/tree/HEAD/packages/babel-helpers) | `7.26.9` | `7.28.4` | | [base-x](https://github.com/cryptocoinjs/base-x) | `3.0.9` | `3.0.11` | | [brace-expansion](https://github.com/juliangruber/brace-expansion) | `1.1.11` | `1.1.12` | | [cipher-base](https://github.com/crypto-browserify/cipher-base) | `1.0.4` | `1.0.7` | | [js-yaml](https://github.com/nodeca/js-yaml) | `3.14.1` | `3.14.2` | | [pbkdf2](https://github.com/browserify/pbkdf2) | `3.1.2` | `3.1.5` | | [sha.js](https://github.com/crypto-browserify/sha.js) | `2.4.11` | `2.4.12` | | [undici](https://github.com/nodejs/undici) | `5.28.5` | `5.29.0` |

Bumps the npm_and_yarn group with 1 update in the /sdks/universal-router-sdk directory: [@openzeppelin/contracts](https://github.com/OpenZeppelin/openzeppelin-contracts).


Updates `@openzeppelin/contracts` from 5.2.0 to 5.4.0
- [Release notes](https://github.com/OpenZeppelin/openzeppelin-contracts/releases)
- [Changelog](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CHANGELOG.md)
- [Commits](https://github.com/OpenZeppelin/openzeppelin-contracts/compare/v5.2.0...v5.4.0)

Updates `@babel/helpers` from 7.26.9 to 7.28.4
- [Release notes](https://github.com/babel/babel/releases)
- [Changelog](https://github.com/babel/babel/blob/main/CHANGELOG.md)
- [Commits](https://github.com/babel/babel/commits/v7.28.4/packages/babel-helpers)

Updates `base-x` from 3.0.9 to 3.0.11
- [Commits](https://github.com/cryptocoinjs/base-x/compare/v3.0.9...v3.0.11)

Updates `brace-expansion` from 1.1.11 to 1.1.12
- [Release notes](https://github.com/juliangruber/brace-expansion/releases)
- [Commits](https://github.com/juliangruber/brace-expansion/compare/1.1.11...v1.1.12)

Updates `cipher-base` from 1.0.4 to 1.0.7
- [Changelog](https://github.com/browserify/cipher-base/blob/master/CHANGELOG.md)
- [Commits](https://github.com/crypto-browserify/cipher-base/compare/v1.0.4...v1.0.7)

Updates `js-yaml` from 3.14.1 to 3.14.2
- [Changelog](https://github.com/nodeca/js-yaml/blob/master/CHANGELOG.md)
- [Commits](https://github.com/nodeca/js-yaml/compare/3.14.1...3.14.2)

Updates `pbkdf2` from 3.1.2 to 3.1.5
- [Changelog](https://github.com/browserify/pbkdf2/blob/master/CHANGELOG.md)
- [Commits](https://github.com/browserify/pbkdf2/compare/v3.1.2...v3.1.5)

Updates `sha.js` from 2.4.11 to 2.4.12
- [Changelog](https://github.com/browserify/sha.js/blob/master/CHANGELOG.md)
- [Commits](https://github.com/crypto-browserify/sha.js/compare/v2.4.11...v2.4.12)

Updates `undici` from 5.28.5 to 5.29.0
- [Release notes](https://github.com/nodejs/undici/releases)
- [Commits](https://github.com/nodejs/undici/compare/v5.28.5...v5.29.0)

Updates `@openzeppelin/contracts` from 5.2.0 to 5.4.0
- [Release notes](https://github.com/OpenZeppelin/openzeppelin-contracts/releases)
- [Changelog](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CHANGELOG.md)
- [Commits](https://github.com/OpenZeppelin/openzeppelin-contracts/compare/v5.2.0...v5.4.0)

---
updated-dependencies:
- dependency-name: "@openzeppelin/contracts" dependency-version: 5.4.0 dependency-type: direct:production dependency-group: npm_and_yarn
- dependency-name: "@babel/helpers" dependency-version: 7.28.4 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: base-x dependency-version: 3.0.11 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: brace-expansion dependency-version: 1.1.12 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: cipher-base dependency-version: 1.0.7 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: js-yaml dependency-version: 3.14.2 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: pbkdf2 dependency-version: 3.1.5 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: sha.js dependency-version: 2.4.12 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: undici dependency-version: 5.29.0 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: "@openzeppelin/contracts" dependency-version: 5.4.0 dependency-type: direct:production dependency-group: npm_and_yarn ...



* chore: rm dist and add to gitignore

* refactor(builders): eliminate duplication in claim builders

Refactored claim builder hierarchy to eliminate code duplication by introducing base classes:

- Created BaseClaimBuilder abstract class with common fields (sponsor, nonce, expires, allocatorData, sponsorSignature, witness)
- Created BaseSingleResourceClaimBuilder extending BaseClaimBuilder with single resource fields (id, allocatedAmount, claimants, lockTag) and methods (addTransfer, addConvert, addWithdraw, addClaimant, addComponent)
- Refactored SingleClaimBuilder to extend BaseSingleResourceClaimBuilder
- Refactored MultichainClaimBuilder to extend BaseSingleResourceClaimBuilder
- Refactored ExogenousMultichainClaimBuilder to extend MultichainClaimBuilder
- Refactored BaseBatchClaimBuilder to extend BaseClaimBuilder

* feat(encoding): add allocatorToAllocatorId conversion function

Implemented allocator address to allocator ID conversion matching the Solidity IdLib.sol implementation:

- Added `allocatorToAllocatorId(allocator: Address): bigint` function to convert allocator addresses to uint96 allocator IDs
- Added internal `toCompactFlag(allocator: Address): number` helper to compute 4-bit compact flags using bit manipulation and population counting
- Compact flag represents the position of the first set bit in the upper 72 bits of the address, used for efficient storage
- Final allocator ID combines: upper 4 bits (compact flag) + lower 88 bits of address

* feat(smart-wallet): add executeUserOp

* feat(tribunal): add random default salt, update types

* chore(deps): bump jws in the npm_and_yarn group across 1 directory

Bumps the npm_and_yarn group with 1 update in the / directory: [jws](https://github.com/brianloveswords/node-jws).


Updates `jws` from 3.2.2 to 3.2.3
- [Release notes](https://github.com/brianloveswords/node-jws/releases)
- [Changelog](https://github.com/auth0/node-jws/blob/master/CHANGELOG.md)
- [Commits](https://github.com/brianloveswords/node-jws/compare/v3.2.2...v3.2.3)

---
updated-dependencies:
- dependency-name: jws dependency-version: 3.2.3 dependency-type: indirect dependency-group: npm_and_yarn ...



* [Snyk] Security upgrade jest from 25.5.0 to 26.0.0 (#31)

* fix: sdks/uniswapx-sdk/package.json to reduce vulnerabilities

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-QS-14724253

* Update sdks/uniswapx-sdk/package.json




---------





* Update sdks/uniswapx-sdk/package.json




* Bumps the npm_and_yarn group with 2 updates in the / directory: [@openzeppelin/contracts](https://github.com/OpenZeppelin/openzeppelin-contracts) and [undici](https://github.com/nodejs/undici). (#33) (#34)

* chore(deps): bump the npm_and_yarn group across 1 directory with 2 updates

Bumps the npm_and_yarn group with 2 updates in the / directory: [@openzeppelin/contracts](https://github.com/OpenZeppelin/openzeppelin-contracts) and [undici](https://github.com/nodejs/undici).


Updates `@openzeppelin/contracts` from 5.1.0 to 5.2.0
- [Release notes](https://github.com/OpenZeppelin/openzeppelin-contracts/releases)
- [Changelog](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CHANGELOG.md)
- [Commits](https://github.com/OpenZeppelin/openzeppelin-contracts/compare/v5.1.0...v5.2.0)

Updates `undici` from 5.28.4 to 5.28.5
- [Release notes](https://github.com/nodejs/undici/releases)
- [Commits](https://github.com/nodejs/undici/compare/v5.28.4...v5.28.5)

---
updated-dependencies:
- dependency-name: "@openzeppelin/contracts" dependency-type: direct:production dependency-group: npm_and_yarn
- dependency-name: undici dependency-type: indirect dependency-group: npm_and_yarn ...



* fix: sdks/universal-router-sdk/package.json to reduce vulnerabilities

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-OPENZEPPELINCONTRACTS-10773735

* Update monorepo-integrity.yml



* chore(deps): bump the npm_and_yarn group across 2 directories with 9 updates

Bumps the npm_and_yarn group with 9 updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| [@openzeppelin/contracts](https://github.com/OpenZeppelin/openzeppelin-contracts) | `5.2.0` | `5.4.0` | | [@babel/helpers](https://github.com/babel/babel/tree/HEAD/packages/babel-helpers) | `7.26.9` | `7.28.4` | | [base-x](https://github.com/cryptocoinjs/base-x) | `3.0.9` | `3.0.11` | | [brace-expansion](https://github.com/juliangruber/brace-expansion) | `1.1.11` | `1.1.12` | | [cipher-base](https://github.com/crypto-browserify/cipher-base) | `1.0.4` | `1.0.7` | | [js-yaml](https://github.com/nodeca/js-yaml) | `3.14.1` | `3.14.2` | | [pbkdf2](https://github.com/browserify/pbkdf2) | `3.1.2` | `3.1.5` | | [sha.js](https://github.com/crypto-browserify/sha.js) | `2.4.11` | `2.4.12` | | [undici](https://github.com/nodejs/undici) | `5.28.5` | `5.29.0` |

Bumps the npm_and_yarn group with 1 update in the /sdks/universal-router-sdk directory: [@openzeppelin/contracts](https://github.com/OpenZeppelin/openzeppelin-contracts).


Updates `@openzeppelin/contracts` from 5.2.0 to 5.4.0
- [Release notes](https://github.com/OpenZeppelin/openzeppelin-contracts/releases)
- [Changelog](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CHANGELOG.md)
- [Commits](https://github.com/OpenZeppelin/openzeppelin-contracts/compare/v5.2.0...v5.4.0)

Updates `@babel/helpers` from 7.26.9 to 7.28.4
- [Release notes](https://github.com/babel/babel/releases)
- [Changelog](https://github.com/babel/babel/blob/main/CHANGELOG.md)
- [Commits](https://github.com/babel/babel/commits/v7.28.4/packages/babel-helpers)

Updates `base-x` from 3.0.9 to 3.0.11
- [Commits](https://github.com/cryptocoinjs/base-x/compare/v3.0.9...v3.0.11)

Updates `brace-expansion` from 1.1.11 to 1.1.12
- [Release notes](https://github.com/juliangruber/brace-expansion/releases)
- [Commits](https://github.com/juliangruber/brace-expansion/compare/1.1.11...v1.1.12)

Updates `cipher-base` from 1.0.4 to 1.0.7
- [Changelog](https://github.com/browserify/cipher-base/blob/master/CHANGELOG.md)
- [Commits](https://github.com/crypto-browserify/cipher-base/compare/v1.0.4...v1.0.7)

Updates `js-yaml` from 3.14.1 to 3.14.2
- [Changelog](https://github.com/nodeca/js-yaml/blob/master/CHANGELOG.md)
- [Commits](https://github.com/nodeca/js-yaml/compare/3.14.1...3.14.2)

Updates `pbkdf2` from 3.1.2 to 3.1.5
- [Changelog](https://github.com/browserify/pbkdf2/blob/master/CHANGELOG.md)
- [Commits](https://github.com/browserify/pbkdf2/compare/v3.1.2...v3.1.5)

Updates `sha.js` from 2.4.11 to 2.4.12
- [Changelog](https://github.com/browserify/sha.js/blob/master/CHANGELOG.md)
- [Commits](https://github.com/crypto-browserify/sha.js/compare/v2.4.11...v2.4.12)

Updates `undici` from 5.28.5 to 5.29.0
- [Release notes](https://github.com/nodejs/undici/releases)
- [Commits](https://github.com/nodejs/undici/compare/v5.28.5...v5.29.0)

Updates `@openzeppelin/contracts` from 5.2.0 to 5.4.0
- [Release notes](https://github.com/OpenZeppelin/openzeppelin-contracts/releases)
- [Changelog](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CHANGELOG.md)
- [Commits](https://github.com/OpenZeppelin/openzeppelin-contracts/compare/v5.2.0...v5.4.0)

---
updated-dependencies:
- dependency-name: "@openzeppelin/contracts" dependency-version: 5.4.0 dependency-type: direct:production dependency-group: npm_and_yarn
- dependency-name: "@babel/helpers" dependency-version: 7.28.4 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: base-x dependency-version: 3.0.11 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: brace-expansion dependency-version: 1.1.12 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: cipher-base dependency-version: 1.0.7 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: js-yaml dependency-version: 3.14.2 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: pbkdf2 dependency-version: 3.1.5 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: sha.js dependency-version: 2.4.12 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: undici dependency-version: 5.29.0 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: "@openzeppelin/contracts" dependency-version: 5.4.0 dependency-type: direct:production dependency-group: npm_and_yarn ...



* chore(deps): bump jws in the npm_and_yarn group across 1 directory

Bumps the npm_and_yarn group with 1 update in the / directory: [jws](https://github.com/brianloveswords/node-jws).


Updates `jws` from 3.2.2 to 3.2.3
- [Release notes](https://github.com/brianloveswords/node-jws/releases)
- [Changelog](https://github.com/auth0/node-jws/blob/master/CHANGELOG.md)
- [Commits](https://github.com/brianloveswords/node-jws/compare/v3.2.2...v3.2.3)

---
updated-dependencies:
- dependency-name: jws dependency-version: 3.2.3 dependency-type: indirect dependency-group: npm_and_yarn ...



* [Snyk] Security upgrade jest from 25.5.0 to 26.0.0 (#31)

* fix: sdks/uniswapx-sdk/package.json to reduce vulnerabilities

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-QS-14724253

* Update sdks/uniswapx-sdk/package.json




---------





* Update sdks/uniswapx-sdk/package.json




---------







* Refactor CircleCI config with custom executor and job (#36)

https://github.com/Dargon789/foundry/commit/14f26f52dbe20e3ad1e33723e6a492a7adf2fc76



* fix: sdks/v3-sdk/package.json to reduce vulnerabilities (#24)

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-FORMDATA-10841150
- https://snyk.io/vuln/SNYK-JS-MICROMATCH-6838728
- https://snyk.io/vuln/SNYK-JS-REQUEST-3361831
- https://snyk.io/vuln/SNYK-JS-TOUGHCOOKIE-5672873
- https://snyk.io/vuln/SNYK-JS-UNSETVALUE-2400660
- https://snyk.io/vuln/SNYK-JS-BRACES-6838727
- https://snyk.io/vuln/SNYK-JS-CROSSSPAWN-8303230



* fix: sdks/router-sdk/package.json to reduce vulnerabilities (#35)

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-FORMDATA-10841150
- https://snyk.io/vuln/SNYK-JS-QS-14724253
- https://snyk.io/vuln/SNYK-JS-BRACES-6838727
- https://snyk.io/vuln/SNYK-JS-CROSSSPAWN-8303230
- https://snyk.io/vuln/SNYK-JS-INFLIGHT-6095116
- https://snyk.io/vuln/SNYK-JS-TMP-11501554
- https://snyk.io/vuln/SNYK-JS-TOUGHCOOKIE-5672873
- https://snyk.io/vuln/SNYK-JS-UNSETVALUE-2400660
- https://snyk.io/vuln/SNYK-JS-REQUEST-3361831
- https://snyk.io/vuln/SNYK-JS-ROLLUP-8073097
- https://snyk.io/vuln/SNYK-JS-SERIALIZEJAVASCRIPT-6147607
- https://snyk.io/vuln/SNYK-JS-MICROMATCH-6838728



* [Snyk] Security upgrade tsdx from 0.14.1 to 2.0.0 (#27)

* fix: sdks/universal-router-sdk/package.json to reduce vulnerabilities

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-FORMDATA-10841150
- https://snyk.io/vuln/SNYK-JS-QS-14724253
- https://snyk.io/vuln/SNYK-JS-BRACES-6838727
- https://snyk.io/vuln/SNYK-JS-CROSSSPAWN-8303230
- https://snyk.io/vuln/SNYK-JS-INFLIGHT-6095116
- https://snyk.io/vuln/SNYK-JS-TMP-11501554
- https://snyk.io/vuln/SNYK-JS-TOUGHCOOKIE-5672873
- https://snyk.io/vuln/SNYK-JS-UNSETVALUE-2400660
- https://snyk.io/vuln/SNYK-JS-REQUEST-3361831
- https://snyk.io/vuln/SNYK-JS-ROLLUP-8073097
- https://snyk.io/vuln/SNYK-JS-SERIALIZEJAVASCRIPT-6147607
- https://snyk.io/vuln/SNYK-JS-MICROMATCH-6838728

* Update sdks/universal-router-sdk/package.json




---------





* Chore(v3 sdk) annotate factory address  (#39)

* chore(v3-sdk): annotate FACTORY_ADDRESS as deprecated

* chore(v3-sdk): annotate FACTORY_ADDRESS as deprecated

* remove .idea artifact

* Update sdks/v3-sdk/src/constants.ts




---------





* update yarn-3.2.3.cjs

.yarn\releases\yarn-3.2.3.cjs

* Update yarn-3.2.3.cjs

* Update yarn-3.2.3.cjs (#43)

* Create config.yml (#44)

https://github.com/Dargon789/foundry/commit/14f26f52dbe20e3ad1e33723e6a492a7adf2fc76



* Update check-pr-title.yaml (#42)



* wip(exarch/tribunal): add exarch support, refactor and improve tribunal impl

* wip(indexing): add tribunal indexer client

* Potential fix for code scanning alert no. 14: Workflow does not contain permissions (#50)




* Update google.yml (#52)



* fix: package.json to reduce vulnerabilities (#49)

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-ESLINT-15102420



* Update check-pr-title.yaml

* chore(deps): bump the npm_and_yarn group across 2 directories with 5 updates (#48)

Bumps the npm_and_yarn group with 5 updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| [@babel/runtime](https://github.com/babel/babel/tree/HEAD/packages/babel-runtime) | `7.18.9` | `7.26.10` | | [@openzeppelin/contracts](https://github.com/OpenZeppelin/openzeppelin-contracts) | `4.7.0` | `4.9.6` | | [js-yaml](https://github.com/nodeca/js-yaml) | `3.14.1` | `3.14.2` | | [jws](https://github.com/brianloveswords/node-jws) | `3.2.2` | `3.2.3` | | [tar](https://github.com/isaacs/node-tar) | `7.5.1` | `7.5.7` |

Bumps the npm_and_yarn group with 1 update in the /sdks/universal-router-sdk directory: [@openzeppelin/contracts](https://github.com/OpenZeppelin/openzeppelin-contracts).


Updates `@babel/runtime` from 7.18.9 to 7.26.10
- [Release notes](https://github.com/babel/babel/releases)
- [Changelog](https://github.com/babel/babel/blob/main/CHANGELOG.md)
- [Commits](https://github.com/babel/babel/commits/v7.26.10/packages/babel-runtime)

Updates `@openzeppelin/contracts` from 4.7.0 to 4.9.6
- [Release notes](https://github.com/OpenZeppelin/openzeppelin-contracts/releases)
- [Changelog](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CHANGELOG.md)
- [Commits](https://github.com/OpenZeppelin/openzeppelin-contracts/compare/v4.7.0...v4.9.6)

Updates `js-yaml` from 3.14.1 to 3.14.2
- [Changelog](https://github.com/nodeca/js-yaml/blob/master/CHANGELOG.md)
- [Commits](https://github.com/nodeca/js-yaml/compare/3.14.1...3.14.2)

Updates `jws` from 3.2.2 to 3.2.3
- [Release notes](https://github.com/brianloveswords/node-jws/releases)
- [Changelog](https://github.com/auth0/node-jws/blob/master/CHANGELOG.md)
- [Commits](https://github.com/brianloveswords/node-jws/compare/v3.2.2...v3.2.3)

Updates `tar` from 7.5.1 to 7.5.7
- [Release notes](https://github.com/isaacs/node-tar/releases)
- [Changelog](https://github.com/isaacs/node-tar/blob/main/CHANGELOG.md)
- [Commits](https://github.com/isaacs/node-tar/compare/v7.5.1...v7.5.7)

Updates `@openzeppelin/contracts` from 4.7.0 to 4.9.6
- [Release notes](https://github.com/OpenZeppelin/openzeppelin-contracts/releases)
- [Changelog](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CHANGELOG.md)
- [Commits](https://github.com/OpenZeppelin/openzeppelin-contracts/compare/v4.7.0...v4.9.6)

Updates `@openzeppelin/contracts` from 4.7.0 to 4.9.6
- [Release notes](https://github.com/OpenZeppelin/openzeppelin-contracts/releases)
- [Changelog](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CHANGELOG.md)
- [Commits](https://github.com/OpenZeppelin/openzeppelin-contracts/compare/v4.7.0...v4.9.6)

Updates `@openzeppelin/contracts` from 4.7.0 to 4.9.6
- [Release notes](https://github.com/OpenZeppelin/openzeppelin-contracts/releases)
- [Changelog](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/CHANGELOG.md)
- [Commits](https://github.com/OpenZeppelin/openzeppelin-contracts/compare/v4.7.0...v4.9.6)

---
updated-dependencies:
- dependency-name: "@babel/runtime" dependency-version: 7.26.10 dependency-type: direct:production dependency-group: npm_and_yarn
- dependency-name: "@openzeppelin/contracts" dependency-version: 4.9.6 dependency-type: direct:production dependency-group: npm_and_yarn
- dependency-name: js-yaml dependency-version: 3.14.2 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: jws dependency-version: 3.2.3 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: tar dependency-version: 7.5.7 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: "@openzeppelin/contracts" dependency-version: 4.9.6 dependency-type: direct:production dependency-group: npm_and_yarn
- dependency-name: "@openzeppelin/contracts" dependency-version: 4.9.6 dependency-type: direct:production dependency-group: npm_and_yarn
- dependency-name: "@openzeppelin/contracts" dependency-version: 4.9.6 dependency-type: direct:production dependency-group: npm_and_yarn ...




* fix: sdks/uniswapx-sdk/package.json to reduce vulnerabilities (#47)

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-ELLIPTIC-14908844



* fix: sdks/universal-router-sdk/package.json to reduce vulnerabilities (#46)

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-ELLIPTIC-14908844



* [Snyk] Security upgrade ethers from 5.8.0 to 6.0.0 (#45)

* fix: sdks/permit2-sdk/package.json to reduce vulnerabilities

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-ELLIPTIC-14908844

* fix: sdks/permit2-sdk/package.json to reduce vulnerabilities

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-ELLIPTIC-14908844

* fix: sdks/permit2-sdk/package.json to reduce vulnerabilities

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-ELLIPTIC-14908844

---------




* fix: sdks/sdk-core/package.json to reduce vulnerabilities (#29)

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-FORMDATA-10841150
- https://snyk.io/vuln/SNYK-JS-QS-14724253
- https://snyk.io/vuln/SNYK-JS-BRACES-6838727
- https://snyk.io/vuln/SNYK-JS-CROSSSPAWN-8303230
- https://snyk.io/vuln/SNYK-JS-INFLIGHT-6095116
- https://snyk.io/vuln/SNYK-JS-TMP-11501554
- https://snyk.io/vuln/SNYK-JS-TOUGHCOOKIE-5672873
- https://snyk.io/vuln/SNYK-JS-UNSETVALUE-2400660
- https://snyk.io/vuln/SNYK-JS-REQUEST-3361831
- https://snyk.io/vuln/SNYK-JS-ROLLUP-8073097
- https://snyk.io/vuln/SNYK-JS-SERIALIZEJAVASCRIPT-6147607
- https://snyk.io/vuln/SNYK-JS-MICROMATCH-6838728



* fix: sdks/universal-router-sdk/package.json to reduce vulnerabilities (#40)

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-OPENZEPPELINCONTRACTS-2958047
- https://snyk.io/vuln/SNYK-JS-OPENZEPPELINCONTRACTS-2958050
- https://snyk.io/vuln/SNYK-JS-OPENZEPPELINCONTRACTS-2964946
- https://snyk.io/vuln/SNYK-JS-OPENZEPPELINCONTRACTS-2965580
- https://snyk.io/vuln/SNYK-JS-OPENZEPPELINCONTRACTS-5425051
- https://snyk.io/vuln/SNYK-JS-OPENZEPPELINCONTRACTS-5672116
- https://snyk.io/vuln/SNYK-JS-OPENZEPPELINCONTRACTS-5711902
- https://snyk.io/vuln/SNYK-JS-OPENZEPPELINCONTRACTS-5838352
- https://snyk.io/vuln/SNYK-JS-OPENZEPPELINCONTRACTS-6346765
- https://snyk.io/vuln/SNYK-JS-OPENZEPPELINCONTRACTS-2980279
- https://snyk.io/vuln/SNYK-JS-OPENZEPPELINCONTRACTS-2965798
- https://snyk.io/vuln/SNYK-JS-OPENZEPPELINCONTRACTS-5425827



* chore(deps): bump the npm_and_yarn group across 1 directory with 3 updates (#57)

Bumps the npm_and_yarn group with 3 updates in the / directory: [eslint](https://github.com/eslint/eslint), [diff](https://github.com/kpdecker/jsdiff) and [lodash](https://github.com/lodash/lodash).


Updates `eslint` from 8.57.1 to 9.26.0
- [Release notes](https://github.com/eslint/eslint/releases)
- [Changelog](https://github.com/eslint/eslint/blob/v9.26.0/CHANGELOG.md)
- [Commits](https://github.com/eslint/eslint/compare/v8.57.1...v9.26.0)

Updates `diff` from 4.0.2 to 4.0.4
- [Changelog](https://github.com/kpdecker/jsdiff/blob/master/release-notes.md)
- [Commits](https://github.com/kpdecker/jsdiff/compare/v4.0.2...v4.0.4)

Updates `lodash` from 4.17.21 to 4.17.23
- [Release notes](https://github.com/lodash/lodash/releases)
- [Commits](https://github.com/lodash/lodash/compare/4.17.21...4.17.23)

---
updated-dependencies:
- dependency-name: eslint dependency-version: 9.26.0 dependency-type: direct:production dependency-group: npm_and_yarn
- dependency-name: diff dependency-version: 4.0.4 dependency-type: indirect dependency-group: npm_and_yarn
- dependency-name: lodash dependency-version: 4.17.23 dependency-type: indirect dependency-group: npm_and_yarn ...




* [Snyk] Fix for 2 vulnerabilities (#56)

* fix: sdks/uniswapx-sdk/package.json to reduce vulnerabilities

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-ELLIPTIC-14908844
- https://snyk.io/vuln/SNYK-JS-ESLINT-15102420

* fix: sdks/uniswapx-sdk/package.json to reduce vulnerabilities

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-ELLIPTIC-14908844
- https://snyk.io/vuln/SNYK-JS-ESLINT-15102420

---------




* [Snyk] Fix for 3 vulnerabilities (#55)

* fix: sdks/uniswapx-sdk/integration/package.json to reduce vulnerabilities

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-ELLIPTIC-14908844
- https://snyk.io/vuln/SNYK-JS-UNDICI-14943963
- https://snyk.io/vuln/SNYK-JS-INFLIGHT-6095116

* fix: sdks/uniswapx-sdk/integration/package.json to reduce vulnerabilities

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-ELLIPTIC-14908844
- https://snyk.io/vuln/SNYK-JS-UNDICI-14943963
- https://snyk.io/vuln/SNYK-JS-INFLIGHT-6095116

---------




* fix: sdks/v2-sdk/package.json to reduce vulnerabilities (#28)

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JS-FORMDATA-10841150
- https://snyk.io/vuln/SNYK-JS-QS-14724253
- https://snyk.io/vuln/SNYK-JS-BRACES-6838727
- https://snyk.io/vuln/SNYK-JS-CROSSSPAWN-8303230
- https://snyk.io/vuln/SNYK-JS-INFLIGHT-6095116
- https://snyk.io/vuln/SNYK-JS-TMP-11501554
- https://snyk.io/vuln/SNYK-JS-TOUGHCOOKIE-5672873
- https://snyk.io/vuln/SNYK-JS-UNSETVALUE-2400660
- https://snyk.io/vuln/SNYK-JS-REQUEST-3361831
- https://snyk.io/vuln/SNYK-JS-ROLLUP-8073097
- https://snyk.io/vuln/SNYK-JS-SERIALIZEJAVASCRIPT-6147607
- https://snyk.io/vuln/SNYK-JS-MICROMATCH-6838728



* feat(uniswapx-sdk): graduate to stable v3.0.0 (Uniswap#545)

* claude prompts claude-pr-review.md

* feat(smart-wallet): add executeUserOp

* Revert "feat(uniswapx-sdk): graduate to stable v3.0.0 (Uniswap#545)"

This reverts commit dc9c963ca155ec9df6800b615037ffdfd2a991a7.

* feat(v2-sdk): bump sdk-core in v2 to support x-layer (#463)

* feat(v3-sdk): Bump sdk-core for v3 to support x-layer (#464)

* feat(v4-sdk): Bump sdk-core version to support x-layer (#465)

* feat(router-sdk): bump sdks for xlayer (#466)

* feat(ur-sdk): bump sdks for xlayer (#467)

## Description

bump sdks in ur-sdk for xlayer

## How Has This Been Tested?

_[e.g. Manually, E2E tests, unit tests, Storybook]_

## Are there any breaking changes?

_[e.g. Type definitions, API definitions]_

If there are breaking changes, please ensure you bump the major version Bump the major version (by using the title `feat(breaking): ...`), post a notice in #eng-sdks, and explicitly notify all Uniswap Labs consumers of the SDK.

## (Optional) Feedback Focus

_[Specific parts of this PR you'd like feedback on, or that reviewers should pay closer attention to]_

## (Optional) Follow Ups

_[Things that weren't addressed in this PR, ways you plan to build on this work, or other ways this work could be extended]_

<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Description
Bumps SDK dependencies in universal-router-sdk and adds X-Layer chain configuration to enable X-Layer support. This follows the recent SDK version bumps (#463, #464, #465, #466) that added X-Layer support to the individual SDKs. ## Changes
- Updated `@uniswap/router-sdk` version in `sdks/universal-router-sdk/package.json` from `^2.1.0` to `^2.3.0`
- Updated `@uniswap/sdk-core` version from `^7.8.0` to `^7.10.0`
- Updated `@uniswap/v2-sdk` version from `^4.16.0` to `^4.17.0`
- Updated `@uniswap/v3-sdk` version from `^3.26.0` to `^3.27.0`
- Updated `@uniswap/v4-sdk` version from `^1.23.0` to `^1.24.0`
- Added X-Layer chain configuration (chain ID 196) in `constants.ts` with WETH address and Universal Router addresses for V1_2, V2_0, and V2_1
- Updated `yarn.lock` to reflect the new dependency versions ## How Has This Been Tested?
Will test in routing
## Are there any breaking changes?
No
<!-- claude-pr-description-end -->

* feat(uniswapx-sdk): add V4 hybrid order support (#432)

* feat(smart-wallet-sdk): add X-Layer support (#468)

* feat(v4-sdk): Revert Add max hop slippage (#470)

* feat(universal-router-sdk): Revert Universal Router 2.1 support (#471)

## Description

Revert Universal Router 2.1 support

## How Has This Been Tested?

_[e.g. Manually, E2E tests, unit tests, Storybook]_

## Are there any breaking changes?

_[e.g. Type definitions, API definitions]_

If there are breaking changes, please ensure you bump the major version Bump the major version (by using the title `feat(breaking): ...`), post a notice in #eng-sdks, and explicitly notify all Uniswap Labs consumers of the SDK.

## (Optional) Feedback Focus

_[Specific parts of this PR you'd like feedback on, or that reviewers should pay closer attention to]_

## (Optional) Follow Ups

_[Things that weren't addressed in this PR, ways you plan to build on this work, or other ways this work could be extended]_

<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Description
Reverts Universal Router 2.1 support that was added in PR #442. This PR removes all v2.1-specific features to roll back to a v2.0-only state. ## Changes
- Removed `UniversalRouterVersion.V2_1` enum value and all v2.1 router addresses from chain configurations
- Deleted `src/utils/eip712.ts` (EIP712 signing utilities for signed route execution)
- Deleted `src/entities/actions/across.ts` (Across V4 bridge types)
- Removed `SignedRouteOptions`, `EIP712Payload` types and `getExecuteSignedPayload()`, `encodeExecuteSigned()` methods from `swapRouter.ts`
- Removed `maxHopSlippage` option from `SwapOptions` interface
- Removed `addAcrossBridge()` method and `ACROSS_V4_DEPOSIT_V3` command from `routerCommands.ts`
- Removed exports: `NONCE_SKIP_CHECK`, `generateNonce`, `EXECUTE_SIGNED_TYPES`, `getUniversalRouterDomain`
- Deleted unit tests for signed routes (`signedRoutes.test.ts`) and Across bridge (`across.test.ts`)
- Removed v2.1 documentation from README.md (per-hop slippage, signed routes, cross-chain bridging) ## How Has This Been Tested?
Unit tests updated to remove v2.1-specific test cases. ## Are there any breaking changes?
Yes - removes the following exports and functionality:
- `UniversalRouterVersion.V2_1`
- `SignedRouteOptions`, `EIP712Payload` types
- `NONCE_SKIP_CHECK`, `generateNonce`, `EXECUTE_SIGNED_TYPES`, `getUniversalRouterDomain` exports
- `SwapRouter.getExecuteSignedPayload()` and `SwapRouter.encodeExecuteSigned()` methods
- `AcrossV4DepositV3Params` type and `CONTRACT_BALANCE` from across module
- `maxHopSlippage` option in `SwapOptions`
- Bridge parameters in `SwapRouter.swapCallParameters()` <!-- claude-pr-description-end -->

* feat(universal-router-sdk): downgrade universal-router to v2.0.0-beta.2 (#473)

* feat(ur-sdk): xlayer UR 2.0 (#472)

## PR Scope

Please title your PR according to the following types and scopes following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/):

- `fix(SDK name):` will trigger a patch version
- `chore(<type>):` will not trigger any release and should be used for internal repo changes
- `<type>(public):` will trigger a patch version for non-code changes (e.g. README changes)
- `feat(SDK name):` will trigger a minor version
- `feat(breaking):` will trigger a major version for a breaking change

## Description

_[Summary of the change, motivation, and context]_

## How Has This Been Tested?

_[e.g. Manually, E2E tests, unit tests, Storybook]_

## Are there any breaking changes?

_[e.g. Type definitions, API definitions]_

If there are breaking changes, please ensure you bump the major version Bump the major version (by using the title `feat(breaking): ...`), post a notice in #eng-sdks, and explicitly notify all Uniswap Labs consumers of the SDK.

## (Optional) Feedback Focus

_[Specific parts of this PR you'd like feedback on, or that reviewers should pay closer attention to]_

## (Optional) Follow Ups

_[Things that weren't addressed in this PR, ways you plan to build on this work, or other ways this work could be extended]_

<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Description
Adds the Universal Router V2.0 deployment configuration for X-Layer (chain ID 196) by updating from placeholder values to the actual deployed contract address. ## Changes
- Updated X-Layer Universal Router V2.0 address from placeholder (`0x0000000000000000000000000000000000000000`) to deployed contract (`0x6bdbd02e751bca2c029cfc21098da04acce8d582`) in `sdks/universal-router-sdk/src/utils/constants.ts`
- Updated X-Layer Universal Router V2.0 creation block from `1` to `47680350` ## How Has This Been Tested?
Will be tested in routing pipeline.
## Are there any breaking changes?
No
<!-- claude-pr-description-end -->

* fix(router-sdk): bump v4-sdk for ur2.1 revert (#474)

* feat(universal-router-sdk): Bump router-sdk version (#475)

* feat(uniswapx-sdk): expand chain 1301 config with Hybrid and Permit2 support (#469)




* fix(v4-sdk): update to use pathInput (#476)




* fix(universal-router-sdk): fix xlayer ur 2.0 address (#479)

* fix(router-sdk): bump v4-sdk to 1.25.1 (priceImpact calc fix) (#477)

* fix(sdk-core): update xlayer v4 position manager address (#480)

* fix(universal-router-sdk): bump v4-sdk and router-sdk (priceImpact calc fix) (#478)

* feat(uniswapx-sdk): add V4 order quoter, validator and integration tests (#481)

* feat(uniswapx-sdk): bubble v4 quoter revert data (#485)

* fix(v4-sdk): eth-weth exact output (#486)

* fix(router-sdk): bump v4-sdk to 1.25.2 in router-sdk (#487)

* fix(universal-router-sdk): handle ETH/WETH output in V4 split routes (#462)



* feat: update ai toolkit ref (#488)




* fix(v4-sdk): eth-weth as starting pool (#490)

* fix(v4-sdk): add comment to trigger release (#492)

* fix(v4-sdk): more edge cases for eth-weth pools (#494)

* fix(router-sdk): bump v4-sdk to 1.25.5 (#493)

* fix(universal-router-sdk): handle ETH-WETH starting pool in split routes (#491)

* fix(v4-sdk): bump sdk-core to 7.10.1 and v3-sdk to 3.27.0 (#496)

* fix(router-sdk): bump sdk-core to 7.10.1 and v4-sdk to 1.25.6 (#497)

* fix(universal-router-sdk): bump router-sdk to 2.3.5 and v4-sdk to 1.25.6 (#498)

* chore(uniswapx-sdk): update hybrid order (#495)

* feat(v4-sdk): add max hop slippage support for multi-hop swaps (#500)

* chore(uniswapx-sdk): new reactor and hook addr (#501)

* feat(v4-sdk): add URVersion parameter to addAction for V2.1 encoding (#502)

* feat(router-sdk): bump v4-sdk to 1.27.0 (#503)

* feat(ur-sdk): Universal Router 2.1 support (#504)




* feat(sdk-core): Add Linea support (#519)

* chore(CODEOWNERS): update CO for swap-be SDKs (#521)

* feat(v3-sdk): bump sdk-core to 7.11.0 (#523)

* feat(v2-sdk): update V2 SDK @uniswap/sdk-core to version 7.11.0 (#522)

* feat(v4-sdk): bump sdk-core to 7.11.0 and v3-sdk to 3.28.0 (#524)

* feat(router-sdk): update SDK versions to 4.18.0, 3.28.0, and 1.28.0 (#525)

* feat(router-sdk): update SDK core versions to 7.11.0 (#526)

* feat(universal-router-sdk): bump SDK dependencies to latest versions (#527)

* feat(sdk-core): add Tempo chain (4217) support (#533)

* feat(v2-sdk, v3-sdk): bump sdk-core to ^7.12.0 for Tempo chain support (#536)

* feat(v4-sdk): bump sdk-core to ^7.12.0 and v3-sdk to 3.29.0 for Tempo (#537)

* feat(router-sdk): bump SDK deps for Tempo chain support (#538)



* fix(sdk-core): remove WETH9 entry for Tempo chain (4217) (#540)

* fix(v2-sdk, v3-sdk): bump sdk-core to ^7.12.1 for Tempo WETH9 fix (#541)

* fix(v4-sdk): bump sdk-core to ^7.12.1 and v3-sdk to 3.29.1 (#542)

* fix(router-sdk): bump all SDK deps for Tempo WETH9 fix (#543)

* feat(universal-router-sdk): add Tempo chain config and bump SDK deps (#534)



* fix: resolve zizmor GitHub Actions security findings (#516)



* feat(universal-router-sdk): add SwapProxy support for no-Permit2 approve+swap flow (#518)

* feat(uniswapx-sdk): graduate to stable v3.0.0 (#545)



* feat: migrate from semantic-release to Changesets with workspace: protocol (#539)



* fix: correct changesets/action SHA in release workflow (#548)



* fix: add registry-url for npm OIDC auth and mark uniswapx-integration private (#549)

* test: dummy sdk-core patch to validate changeset workflow (#547)



* fix: use exact workspace versions for cascading changesets (#551)

* fix: remove registry-url to fix npm Trusted Publishing OIDC auth (#552)



* chore: Version Packages (#550)




* chore: remove push-branches-from-main workflow (#555)



* ci: skip unnecessary workflows on changeset-release branches (#554)



* fix(v4-sdk): increase liquidity fix (#558)

* feat(router-sdk): add maxHopSlippage to Trade.swaps (#529)

## Description

For maxHopSlippage, **a partial implementation exists for multi-hop V4-only routes in UR-sdk, but it is incorrect:**

1. Flat array on **`SwapOptions`** -- A single `maxHopSlippage?: BigNumber[]` on `SwapOptions` cannot correctly map values to specific routes in a split-route trade (e.g. 40% Route A with 3 hops, 60% Route B with 2 hops).
2. Mixed routes pass the full array -- In `addMixedSwap`, the entire `options.maxHopSlippage` array is passed to V4 sections without slicing; V2/V3 sections get nothing.



**We need to ensure that per-hop slippage is saved per** **_route_** **data model, not per** **_trade_** **(i.e. for split route trades)**

**This PR adds** `maxHopSlippage` **support to the** `Trade.swaps` **object in router-sdk, enabling per-hop slippage protection for multi-hop swaps across all route types (V2, V3, V4, and mixed routes)**

## How Has This Been Tested?

_[e.g. Manually, E2E tests, unit tests, Storybook]_

## Are there any breaking changes?


Purely additive, no breaking changes, no existing code uses the new field yet. Can merge independently.

## Follow Ups

- in order to be used in UR-sdk, need to publish minor version bump to router-sdk



<!-- claude-pr-description-start -->

---

## :sparkles: Claude-Generated Content

## Summary

Adds `maxHopSlippage` support to the `Trade` class in router-sdk, enabling per-hop slippage protection for multi-hop swaps across all route types (V2, V3, V4, and mixed routes).

## Changes

- Added optional `maxHopSlippage?: bigint[]` field to the `swaps` array type in `Trade` class
- Extended route input types for V2, V3, V4, and mixed routes to accept `maxHopSlippage` parameter
- Propagated `maxHopSlippage` through the constructor for all route types
- Extended `fromRoutes()` static method to pass `maxHopSlippage` through populated routes

## How Has This Been Tested?

This is a type extension.

## Are there any breaking changes?

No - `maxHopSlippage` is an optional parameter with no changes to existing behavior.

<!-- claude-pr-description-end -->

* feat(breaking): switch v4-sdk from UR v2.1 to UR v2.1.1 & add single-hop ABI struct (#530)

## Description

- Rename URVersion.V2_1 to `V2_1_1 `in v4-sdk
- Rename V4_SWAP_ACTIONS_V2_1 to `V4_SWAP_ACTIONS_V2_1_1` and update all references in v4Planner.ts

## How Has This Been Tested?

_[e.g. Manually, E2E tests, unit tests, Storybook]_

## Are there any breaking changes?

The version rename is breaking. (And it is intentionally breaking, as opposed to keeping v2.1 around, because v2.1.1 fixes a precision bug. Plus we don't actually use v2.1 in prod yet)

1. publish v4-sdk as major version
2. update UR-sdk and router-SDK

## (Optional) Feedback Focus

_[Specific parts of this PR you'd like feedback on, or that reviewers should pay closer attention to]_

## (Optional) Follow Ups

Need to explicitly update UR-sdk and router-SDK versions

<!-- claude-pr-description-start -->

---

## :sparkles: Claude-Generated Content

## Summary

Updates v4-sdk to use Universal Router version 2.1.1 instead of 2.1 by renaming version enums, ABI definitions, and struct types throughout the codebase. Adds V2.1.1-specific struct definitions for single-hop swap actions.

## Changes

- Renamed `URVersion.V2_1` to `URVersion.V2_1_1` in the `URVersion` enum
- Renamed `V4_SWAP_ACTIONS_V2_1` to `V4_SWAP_ACTIONS_V2_1_1` and expanded to include single-hop swap actions (`SWAP_EXACT_IN_SINGLE`, `SWAP_EXACT_OUT_SINGLE`)
- Added new V2.1.1 struct definitions with `maxHopSlippage` field:
    - `SWAP_EXACT_IN_SINGLE_STRUCT_V2_1_1`
    - `SWAP_EXACT_IN_STRUCT_V2_1_1`
    - `SWAP_EXACT_OUT_SINGLE_STRUCT_V2_1_1`
    - `SWAP_EXACT_OUT_STRUCT_V2_1_1`
- Renamed V2.0 single-hop structs to be explicit: `SWAP_EXACT_IN_SINGLE_STRUCT_V2_0`, `SWAP_EXACT_OUT_SINGLE_STRUCT_V2_0`
- Refactored `addTrade` method to use conditional spread operator for cleaner version-specific struct building
- Added validation that `maxHopSlippage` length matches `route.pools.length`
- Updated `v4BaseActionsParser.ts` to use the new version enum and ABI definitions
- Updated all comments referencing "V2.1" to "V2.1.1"
- Updated all test files to use `URVersion.V2_1_1`

## How Has This Been Tested?

Existing unit tests updated to use the new version constant.

## Are there any breaking changes?

Yes - this is a breaking change for consumers using `URVersion.V2_1` or `V4_SWAP_ACTIONS_V2_1`. They will need to update to `URVersion.V2_1_1` and `V4_SWAP_ACTIONS_V2_1_1` respectively.

<!-- claude-pr-description-end -->

* feat(universal-router-sdk): v2.1.1 version rename & ABI structs (#531)

## Description



TODO : Need to explicitly update UR-sdk and router-SDK versions based on v4-sdk breaking changes

- Rename UniversalRouterVersion.V2_1 to V2_1_1 in constants.ts + update contract addresses
- Add V2.1.1 ABI definitions for V2/V3 swap commands in routerCommands.ts (the new V2V3_SWAP_COMMANDS_V2_1_1 map)
- Make addCommand/createCommand accept optional urVersion parameter for ABI selection

This is all infrastructure/plumbing. The new V2.1.1 ABI defs exist but nothing calls them yet. The version rename is technically breaking but no consumers use UR V2.1 from the SDK.

## How Has This Been Tested?

_[e.g. Manually, E2E tests, unit tests, Storybook]_

## Are there any breaking changes?

_[e.g. Type definitions, API definitions]_

If there are breaking changes, please ensure you bump the major version Bump the major version (by using the title `feat(breaking): ...`), post a notice in #eng-sdks, and explicitly notify all Uniswap Labs consumers of the SDK.

## (Optional) Feedback Focus

_[Specific parts of this PR you'd like feedback on, or that reviewers should pay closer attention to]_

## (Optional) Follow Ups

_[Things that weren't addressed in this PR, ways you plan to build on this work, or other ways this work could be extended]_

<!-- claude-pr-description-start -->

---

## :sparkles: Claude-Generated Content

## Summary

Renames `UniversalRouterVersion.V2_1` to `V2_1_1` and adds ABI infrastructure for V2.1.1 swap commands with `maxHopSlippage` support.

## Changes

- Renamed `UniversalRouterVersion.V2_1` to `V2_1_1` in `constants.ts` enum (version string `'2.1'` → `'2.1.1'`)
- Updated all chain configs (20+ chains) to use `[UniversalRouterVersion.V2_1_1]` key
- Added `V2V3_SWAP_COMMANDS_V2_1_1` ABI definitions for V2/V3 swap commands with extended `maxHopSlippage` parameter:
    - `V3_SWAP_EXACT_IN`
    - `V3_SWAP_EXACT_OUT`
    - `V2_SWAP_EXACT_IN`
    - `V2_SWAP_EXACT_OUT`
- Updated `addCommand()` and `createCommand()` to accept optional `urVersion` parameter for ABI selection
- Fixed comment typo in `Parser.V3Actions` case ("v4 swap data" → "v3 position data")

## How Has This Been Tested?

Infrastructure/plumbing changes only - the new V2.1.1 ABI definitions exist but are not yet called by any code paths.

## Are there any breaking changes?

The version enum rename from `V2_1` to `V2_1_1` is technically breaking, but per the design doc, no consumers currently use V2.1.

<!-- claude-pr-description-end -->

* feat(universal-router-sdk): wire up per-hop slippage encoding (#532)

## Description

- Remove maxHopSlippage from SwapOptions
- Update Swap interface to carry maxHopSlippage (from trade.swaps)
- addV2Swap / addV3Swap: branch on urVersion to encode with or without maxHopSlippage
- addV4Swap: read maxHopSlippage from swap instead of options
- addMixedSwap: slice maxHopSlippage per section with hop offset tracking
- Tests for all protocol paths (V2, V3, V4, mixed) with and without per-hop slippage

## How Has This Been Tested?

_[e.g. Manually, E2E tests, unit tests, Storybook]_

## Are there any breaking changes?

If consumers want to use UR v2.1.1, they must update to this version of the UR-sdk.

<!-- claude-pr-description-start -->
---
## :spark…

## PR Scope

Please title your PR according to the following types and scopes following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/):

- `fix(SDK name):` will trigger a patch version
- `chore(<type>):` will not trigger any release and should be used for internal repo changes
- `<type>(public):` will trigger a patch version for non-code changes (e.g. README changes)
- `feat(SDK name):` will trigger a minor version
- `feat(breaking):` will trigger a major version for a breaking change

## Description

_[Summary of the change, motivation, and context]_

## How Has This Been Tested?

_[e.g. Manually, E2E tests, unit tests, Storybook]_

## Are there any breaking changes?

_[e.g. Type definitions, API definitions]_

If there are breaking changes, please ensure you bump the major version Bump the major version (by using the title `feat(breaking): ...`), post a notice in #eng-sdks, and explicitly notify all Uniswap Labs consumers of the SDK.

## (Optional) Feedback Focus

_[Specific parts of this PR you'd like feedback on, or that reviewers should pay closer attention to]_

## (Optional) Follow Ups

_[Things that weren't addressed in this PR, ways you plan to build on this work, or other ways this work could be extended]_

## Summary by Sourcery

Add smart wallet user operation encoding API and tests while updating a Hardhat matcher dev dependency.

New Features:
- Introduce SmartWallet.encodeUserOp helper to build EntryPoint-compatible user operation calldata and value for batched calls.
- Add unit tests covering single, multiple, and chain-specific calls plus revertOnFailure behavior for user operation encoding.

Enhancements:
- Update smart wallet batching to reuse existing BatchedCallPlanner encoding logic for user operation calls.

Build:
- Bump @nomicfoundation/hardhat-chai-matchers dev dependency in the UniswapX integration package.

Tests:
- Add comprehensive tests for SmartWallet.encodeUserOp including value aggregation, selector checks, and revertOnFailure defaults.